### PR TITLE
Remove unnecessary flushes and yields

### DIFF
--- a/backend/gradio_rerun/rerun.py
+++ b/backend/gradio_rerun/rerun.py
@@ -19,7 +19,7 @@ class RerunData(GradioRootModel):
     `FileData` is used for data served from Gradio, while `str` is used for URLs Rerun will open from a remote server.
     """
 
-    root: Sequence[FileData | Path | str]
+    root: Sequence[FileData | Path | str] | None
 
 
 class Rerun(Component, StreamingOutput):
@@ -142,7 +142,7 @@ class Rerun(Component, StreamingOutput):
 
         """
         if value is None:
-            return RerunData(root=[])
+            return RerunData(root=None)
 
         if isinstance(value, bytes):
             if self.streaming:

--- a/demo/app.py
+++ b/demo/app.py
@@ -71,10 +71,6 @@ def streaming_repeated_blur(recording_id: str, img):
         # you want the user to be able to see progress.
         yield stream.read()
 
-    # Ensure we consume everything from the recording.
-    stream.flush()
-    yield stream.read()
-
 
 # In this example the user is able to add keypoints to an image visualized in Rerun.
 # These keypoints are stored in the global state, we use the session id to keep track of which keypoints belong
@@ -146,8 +142,6 @@ def register_keypoint(
     rec.set_time("iteration", sequence=index)
     rec.log(f"{item.entity_path}/keypoint", rr.Points2D(keypoints, radii=2))
 
-    # Ensure we consume everything from the recording.
-    stream.flush()
     yield stream.read()
 
 


### PR DESCRIPTION
When adding those, I forgot that `read()` (no args) is already equivalent to `flush()` + `read()`. Tested locally to still work as expected in the streaming blur example.

After https://github.com/rerun-io/rerun/pull/9749, `stream.read()` can also yield `None`, so to account for that, `RerunData`'s `root` field can now be `None` as well. We already handle that in the frontend.