### PR TITLE
Add time cursor commands to the Gradio viewer

### DIFF
--- a/.github/workflows/reusable_checks_python.yml
+++ b/.github/workflows/reusable_checks_python.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Lint Python
         run: uv run ruff check
 
+      - name: Test Python
+        run: uv run python -m unittest discover -s tests
+
       - name: Typecheck Python
         run: uv run mypy backend demo --exclude-gitignore
 

--- a/README.md
+++ b/README.md
@@ -545,7 +545,12 @@ The code snippet below is accurate in cases where the component is used as both 
  ```python
  def predict(
      value: RerunData | None
- ) -> list[pathlib.Path | str] | pathlib.Path | str | bytes:
+ ) -> list[pathlib.Path | str]
+    | pathlib.Path
+    | str
+    | bytes
+    | dict[str, str | int | bool | None]
+    | None:
      return value
  ```
  
@@ -553,5 +558,9 @@ The code snippet below is accurate in cases where the component is used as both 
 ## `RerunData`
 ```python
 class RerunData(GradioRootModel):
-    root: Sequence[FileData | Path | str] | None
+    root: (
+        Sequence[FileData | Path | str]
+        | dict[str, str | int | bool | None]
+        | None
+    )
 ```

--- a/README.md
+++ b/README.md
@@ -515,19 +515,6 @@ dict[str, typing.Any] | None
 <td align="left"><code>None</code></td>
 <td align="left">Force viewer panels to a specific state.</td>
 </tr>
-
-<tr>
-<td align="left"><code>command</code></td>
-<td align="left" style="width: 25%;">
-
-```python
-TimeControlCommand | None
-```
-
-</td>
-<td align="left"><code>None</code></td>
-<td align="left">A viewer command sent by a component property update.</td>
-</tr>
 </tbody></table>
 
 
@@ -562,16 +549,6 @@ The code snippet below is accurate in cases where the component is used as both 
      return value
  ```
  
-
-## `TimeControlCommand`
-```python
-class TimeControlCommand(TypedDict):
-    id: str
-    type: Literal["time_ctrl"]
-    timeline: str | None
-    time: int
-    play: bool
-```
 
 ## `RerunData`
 ```python

--- a/README.md
+++ b/README.md
@@ -515,6 +515,19 @@ dict[str, typing.Any] | None
 <td align="left"><code>None</code></td>
 <td align="left">Force viewer panels to a specific state.</td>
 </tr>
+
+<tr>
+<td align="left"><code>command</code></td>
+<td align="left" style="width: 25%;">
+
+```python
+TimeControlCommand | None
+```
+
+</td>
+<td align="left"><code>None</code></td>
+<td align="left">A viewer command sent by a component property update.</td>
+</tr>
 </tbody></table>
 
 
@@ -545,22 +558,23 @@ The code snippet below is accurate in cases where the component is used as both 
  ```python
  def predict(
      value: RerunData | None
- ) -> list[pathlib.Path | str]
-    | pathlib.Path
-    | str
-    | bytes
-    | dict[str, str | int | bool | None]
-    | None:
+ ) -> list[pathlib.Path | str] | pathlib.Path | str | bytes | None:
      return value
  ```
  
 
+## `TimeControlCommand`
+```python
+class TimeControlCommand(TypedDict):
+    id: str
+    type: Literal["time_ctrl"]
+    timeline: str | None
+    time: int
+    play: bool
+```
+
 ## `RerunData`
 ```python
 class RerunData(GradioRootModel):
-    root: (
-        Sequence[FileData | Path | str]
-        | dict[str, str | int | bool | None]
-        | None
-    )
+    root: Sequence[FileData | Path | str] | None
 ```

--- a/backend/gradio_rerun/commands.py
+++ b/backend/gradio_rerun/commands.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     import numpy as np
 
 
-class TimeControlCommand(TypedDict):
+class _TimeControlCommand(TypedDict):
     """Serializable command consumed by the embedded viewer."""
 
     id: str
@@ -24,18 +24,18 @@ class TimeControlCommand(TypedDict):
     play: bool
 
 
-class SetTimeUpdate(TypedDict):
+class _SetTimeUpdate(TypedDict):
     """Gradio property update containing a time-control command."""
 
-    command: TimeControlCommand
+    _command: _TimeControlCommand
     __type__: Literal["update"]
 
 
-__all__ = ["SetTimeUpdate", "TimeControlCommand", "set_time"]
+__all__ = ["set_time"]
 
 
 @overload
-def set_time(timeline: str | None = None, *, sequence: int, play: bool = False) -> SetTimeUpdate: ...
+def set_time(timeline: str | None = None, *, sequence: int, play: bool = False) -> _SetTimeUpdate: ...
 
 
 @overload
@@ -44,7 +44,7 @@ def set_time(
     *,
     duration: int | float | timedelta | np.timedelta64,
     play: bool = False,
-) -> SetTimeUpdate: ...
+) -> _SetTimeUpdate: ...
 
 
 @overload
@@ -53,7 +53,7 @@ def set_time(
     *,
     timestamp: int | float | datetime | np.datetime64,
     play: bool = False,
-) -> SetTimeUpdate: ...
+) -> _SetTimeUpdate: ...
 
 
 def set_time(
@@ -63,7 +63,7 @@ def set_time(
     duration: int | float | timedelta | np.timedelta64 | None = None,
     timestamp: int | float | datetime | np.datetime64 | None = None,
     play: bool = False,
-) -> SetTimeUpdate:
+) -> _SetTimeUpdate:
     """
     Create a Gradio update that sets the embedded viewer's time cursor.
 
@@ -92,11 +92,11 @@ def set_time(
         assert timestamp is not None
         time = to_nanos_since_epoch(timestamp)
 
-    command: TimeControlCommand = TimeControlCommand(
+    command: _TimeControlCommand = _TimeControlCommand(
         id=uuid4().hex,
         type="time_ctrl",
         timeline=timeline,
         time=time,
         play=play,
     )
-    return cast("SetTimeUpdate", gradio_update(command=command))
+    return cast("_SetTimeUpdate", gradio_update(_command=command))

--- a/backend/gradio_rerun/commands.py
+++ b/backend/gradio_rerun/commands.py
@@ -1,0 +1,82 @@
+"""Commands sent from Gradio callbacks to the embedded Rerun viewer."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeAlias, overload
+
+from rerun.time import to_nanos, to_nanos_since_epoch
+
+if TYPE_CHECKING:
+    from datetime import datetime, timedelta
+
+    import numpy as np
+
+
+SetTimeCommand: TypeAlias = dict[str, str | int | bool | None]
+
+__all__ = ["SetTimeCommand", "set_time"]
+
+
+@overload
+def set_time(timeline: str | None = None, *, sequence: int, play: bool = False) -> SetTimeCommand: ...
+
+
+@overload
+def set_time(
+    timeline: str | None = None,
+    *,
+    duration: int | float | timedelta | np.timedelta64,
+    play: bool = False,
+) -> SetTimeCommand: ...
+
+
+@overload
+def set_time(
+    timeline: str | None = None,
+    *,
+    timestamp: int | float | datetime | np.datetime64,
+    play: bool = False,
+) -> SetTimeCommand: ...
+
+
+def set_time(
+    timeline: str | None = None,
+    *,
+    sequence: int | None = None,
+    duration: int | float | timedelta | np.timedelta64 | None = None,
+    timestamp: int | float | datetime | np.datetime64 | None = None,
+    play: bool = False,
+) -> SetTimeCommand:
+    """
+    Create a command that sets the embedded viewer's time cursor.
+
+    Return this command from a Gradio callback whose output is a [`Rerun`][gradio_rerun.Rerun] component.
+    If `timeline` is omitted, the viewer uses its active timeline.
+    Exactly one of `sequence`, `duration`, or `timestamp` must be set.
+
+    Example:
+        ```python
+        from gradio_rerun.commands import set_time
+
+        def seek(frame: int):
+            return set_time(sequence=frame)
+        ```
+
+    """
+    if sum(value is not None for value in (sequence, duration, timestamp)) != 1:
+        raise ValueError("set_time expects exactly one of sequence, duration, or timestamp")
+
+    if sequence is not None:
+        time = sequence
+    elif duration is not None:
+        time = to_nanos(duration)
+    else:
+        assert timestamp is not None
+        time = to_nanos_since_epoch(timestamp)
+
+    return {
+        "command": "set_time",
+        "timeline": timeline,
+        "time": time,
+        "play": play,
+    }

--- a/backend/gradio_rerun/commands.py
+++ b/backend/gradio_rerun/commands.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeAlias, overload
+from typing import TYPE_CHECKING, Literal, TypedDict, cast, overload
+from uuid import uuid4
 
+from gradio import update as gradio_update
 from rerun.time import to_nanos, to_nanos_since_epoch
 
 if TYPE_CHECKING:
@@ -12,13 +14,28 @@ if TYPE_CHECKING:
     import numpy as np
 
 
-SetTimeCommand: TypeAlias = dict[str, str | int | bool | None]
+class TimeControlCommand(TypedDict):
+    """Serializable command consumed by the embedded viewer."""
 
-__all__ = ["SetTimeCommand", "set_time"]
+    id: str
+    type: Literal["time_ctrl"]
+    timeline: str | None
+    time: int
+    play: bool
+
+
+class SetTimeUpdate(TypedDict):
+    """Gradio property update containing a time-control command."""
+
+    command: TimeControlCommand
+    __type__: Literal["update"]
+
+
+__all__ = ["SetTimeUpdate", "TimeControlCommand", "set_time"]
 
 
 @overload
-def set_time(timeline: str | None = None, *, sequence: int, play: bool = False) -> SetTimeCommand: ...
+def set_time(timeline: str | None = None, *, sequence: int, play: bool = False) -> SetTimeUpdate: ...
 
 
 @overload
@@ -27,7 +44,7 @@ def set_time(
     *,
     duration: int | float | timedelta | np.timedelta64,
     play: bool = False,
-) -> SetTimeCommand: ...
+) -> SetTimeUpdate: ...
 
 
 @overload
@@ -36,7 +53,7 @@ def set_time(
     *,
     timestamp: int | float | datetime | np.datetime64,
     play: bool = False,
-) -> SetTimeCommand: ...
+) -> SetTimeUpdate: ...
 
 
 def set_time(
@@ -46,11 +63,12 @@ def set_time(
     duration: int | float | timedelta | np.timedelta64 | None = None,
     timestamp: int | float | datetime | np.datetime64 | None = None,
     play: bool = False,
-) -> SetTimeCommand:
+) -> SetTimeUpdate:
     """
-    Create a command that sets the embedded viewer's time cursor.
+    Create a Gradio update that sets the embedded viewer's time cursor.
 
-    Return this command from a Gradio callback whose output is a [`Rerun`][gradio_rerun.Rerun] component.
+    Return this update from a Gradio callback whose output is a [`Rerun`][gradio_rerun.Rerun] component.
+    The recording remains the component's value; the cursor update travels through a separate command property.
     If `timeline` is omitted, the viewer uses its active timeline.
     Exactly one of `sequence`, `duration`, or `timestamp` must be set.
 
@@ -67,16 +85,18 @@ def set_time(
         raise ValueError("set_time expects exactly one of sequence, duration, or timestamp")
 
     if sequence is not None:
-        time = sequence
+        time: int = sequence
     elif duration is not None:
         time = to_nanos(duration)
     else:
         assert timestamp is not None
         time = to_nanos_since_epoch(timestamp)
 
-    return {
-        "command": "set_time",
-        "timeline": timeline,
-        "time": time,
-        "play": play,
-    }
+    command: TimeControlCommand = TimeControlCommand(
+        id=uuid4().hex,
+        type="time_ctrl",
+        timeline=timeline,
+        time=time,
+        play=play,
+    )
+    return cast("SetTimeUpdate", gradio_update(command=command))

--- a/backend/gradio_rerun/rerun.py
+++ b/backend/gradio_rerun/rerun.py
@@ -11,6 +11,8 @@ from gradio.components.base import Component, StreamingOutput
 from gradio.data_classes import FileData, GradioRootModel, MediaStreamChunk
 from gradio.events import EventListener
 
+from gradio_rerun.commands import TimeControlCommand
+
 
 class RerunData(GradioRootModel):
     """
@@ -19,7 +21,7 @@ class RerunData(GradioRootModel):
     `FileData` is used for data served from Gradio, while `str` is used for URLs Rerun will open from a remote server.
     """
 
-    root: Sequence[FileData | Path | str] | dict[str, str | int | bool | None] | None
+    root: Sequence[FileData | Path | str] | None
 
 
 class Rerun(Component, StreamingOutput):
@@ -71,6 +73,7 @@ class Rerun(Component, StreamingOutput):
         elem_classes: list[str] | str | None = None,
         render: bool = True,
         panel_states: dict[str, Any] | None = None,
+        command: TimeControlCommand | None = None,
     ):
         """
         Initialize a Rerun Viewer block.
@@ -109,11 +112,14 @@ class Rerun(Component, StreamingOutput):
                 Any panels set cannot be toggled by the user in the viewer.
                 Panel names are "top", "blueprint", "selection", and "time".
                 States are "hidden", "collapsed", and "expanded".
+            command: A viewer command sent by a component property update.
+                Use [`set_time`][gradio_rerun.commands.set_time] instead of setting this directly.
 
         """
         self.height = height
         self.streaming = streaming
         self.panel_states = panel_states
+        self.command = command
         super().__init__(
             label=label,
             every=every,
@@ -132,6 +138,7 @@ class Rerun(Component, StreamingOutput):
     def get_config(self):
         config = super().get_config()
         config["panel_states"] = self.panel_states
+        config["command"] = self.command
         return config
 
     def preprocess(self, payload: RerunData | None) -> RerunData | None:
@@ -149,10 +156,7 @@ class Rerun(Component, StreamingOutput):
             return None
         return payload
 
-    def postprocess(
-        self,
-        value: list[Path | str] | Path | str | bytes | dict[str, str | int | bool | None] | None,
-    ) -> RerunData | bytes:
+    def postprocess(self, value: list[Path | str] | Path | str | bytes | None) -> RerunData | bytes:
         """
         Post process the value.
 
@@ -165,11 +169,6 @@ class Rerun(Component, StreamingOutput):
         """
         if value is None:
             return RerunData(root=None)
-
-        if isinstance(value, dict):
-            if value.get("command") == "set_time":
-                return RerunData(root=value)
-            raise ValueError(f"Unknown Rerun viewer command: {value.get('command')!r}")
 
         if isinstance(value, bytes):
             if self.streaming:

--- a/backend/gradio_rerun/rerun.py
+++ b/backend/gradio_rerun/rerun.py
@@ -11,7 +11,7 @@ from gradio.components.base import Component, StreamingOutput
 from gradio.data_classes import FileData, GradioRootModel, MediaStreamChunk
 from gradio.events import EventListener
 
-from gradio_rerun.commands import TimeControlCommand
+from gradio_rerun.commands import _TimeControlCommand
 
 
 class RerunData(GradioRootModel):
@@ -73,7 +73,7 @@ class Rerun(Component, StreamingOutput):
         elem_classes: list[str] | str | None = None,
         render: bool = True,
         panel_states: dict[str, Any] | None = None,
-        command: TimeControlCommand | None = None,
+        _command=None,
     ):
         """
         Initialize a Rerun Viewer block.
@@ -112,14 +112,12 @@ class Rerun(Component, StreamingOutput):
                 Any panels set cannot be toggled by the user in the viewer.
                 Panel names are "top", "blueprint", "selection", and "time".
                 States are "hidden", "collapsed", and "expanded".
-            command: A viewer command sent by a component property update.
-                Use [`set_time`][gradio_rerun.commands.set_time] instead of setting this directly.
 
         """
         self.height = height
         self.streaming = streaming
         self.panel_states = panel_states
-        self.command = command
+        self._command: _TimeControlCommand | None = _command
         super().__init__(
             label=label,
             every=every,
@@ -138,7 +136,7 @@ class Rerun(Component, StreamingOutput):
     def get_config(self):
         config = super().get_config()
         config["panel_states"] = self.panel_states
-        config["command"] = self.command
+        config["_command"] = self._command
         return config
 
     def preprocess(self, payload: RerunData | None) -> RerunData | None:

--- a/backend/gradio_rerun/rerun.py
+++ b/backend/gradio_rerun/rerun.py
@@ -19,7 +19,7 @@ class RerunData(GradioRootModel):
     `FileData` is used for data served from Gradio, while `str` is used for URLs Rerun will open from a remote server.
     """
 
-    root: Sequence[FileData | Path | str] | None
+    root: Sequence[FileData | Path | str] | dict[str, str | int | bool | None] | None
 
 
 class Rerun(Component, StreamingOutput):
@@ -149,7 +149,10 @@ class Rerun(Component, StreamingOutput):
             return None
         return payload
 
-    def postprocess(self, value: list[Path | str] | Path | str | bytes) -> RerunData | bytes:
+    def postprocess(
+        self,
+        value: list[Path | str] | Path | str | bytes | dict[str, str | int | bool | None] | None,
+    ) -> RerunData | bytes:
         """
         Post process the value.
 
@@ -162,6 +165,11 @@ class Rerun(Component, StreamingOutput):
         """
         if value is None:
             return RerunData(root=None)
+
+        if isinstance(value, dict):
+            if value.get("command") == "set_time":
+                return RerunData(root=value)
+            raise ValueError(f"Unknown Rerun viewer command: {value.get('command')!r}")
 
         if isinstance(value, bytes):
             if self.streaming:

--- a/frontend/Index.svelte
+++ b/frontend/Index.svelte
@@ -18,8 +18,9 @@
 		is_stream: boolean;
 	}
 
-	interface SetTimeCommand {
-		command: 'set_time';
+	interface TimeControlCommand {
+		id: string;
+		type: 'time_ctrl';
 		timeline: string | null;
 		time: number;
 		play: boolean;
@@ -35,10 +36,11 @@
 	}
 
 	interface RerunProps {
-		value: null | BinaryStream | SetTimeCommand | (FileData | string)[];
+		value: null | BinaryStream | (FileData | string)[];
 		height: number | string;
 		streaming: boolean;
 		panel_states: { [K in Panel]: PanelState } | null;
+		command: TimeControlCommand | null | undefined;
 	}
 
 	class RerunGradio extends Gradio<RerunEvents, RerunProps> {}
@@ -50,6 +52,8 @@
 	let channel: LogChannel;
 	let ref = $state<HTMLDivElement>();
 	let dragging = $state(false);
+	let pending_command: TimeControlCommand | null = null;
+	let last_command_id: string | null = null;
 
 	/**
 	 * Used to keep track of the playlist currently being fetched
@@ -109,29 +113,6 @@
 			return;
 		}
 
-		if (!Array.isArray(value) && 'command' in value && value.command === 'set_time') {
-			const recording_id = rr.get_active_recording_id();
-			if (recording_id === null) {
-				console.warn('Cannot set Rerun time cursor: no recording is active');
-				return;
-			}
-
-			const active_timeline = rr.get_active_timeline(recording_id);
-			const timeline = value.timeline ?? active_timeline;
-			if (timeline === null) {
-				console.warn('Cannot set Rerun time cursor: no timeline is active');
-				return;
-			}
-
-			if (timeline !== active_timeline) {
-				rr.set_active_timeline(recording_id, timeline);
-			}
-
-			rr.set_playing(recording_id, value.play);
-			rr.set_current_time(recording_id, timeline, value.time);
-			return;
-		}
-
 		// List of static or dynamic rrd URLs.
 		// We just let the Viewer handle the streaming.
 		if (Array.isArray(value)) {
@@ -169,6 +150,46 @@
 		rr.open(value.url);
 	}
 
+	function try_apply_command(
+		command: TimeControlCommand | null | undefined = pending_command ?? gradio.props.command
+	) {
+		if (command == null || command.type !== 'time_ctrl' || command.id === last_command_id) {
+			return;
+		}
+
+		pending_command = command;
+		if (rr === undefined || !rr.ready) {
+			return;
+		}
+
+		const recording_id = rr.get_active_recording_id();
+		if (recording_id === null) {
+			return;
+		}
+
+		const active_timeline = rr.get_active_timeline(recording_id);
+		if (command.timeline !== null && command.timeline !== active_timeline) {
+			rr.set_active_timeline(recording_id, command.timeline);
+		}
+
+		const timeline = rr.get_active_timeline(recording_id);
+		if (timeline === null) {
+			return;
+		}
+		if (command.timeline !== null && timeline !== command.timeline) {
+			return;
+		}
+		if (command.id === last_command_id) {
+			return;
+		}
+
+		last_command_id = command.id;
+		pending_command = null;
+
+		rr.set_playing(recording_id, command.play);
+		rr.set_current_time(recording_id, timeline, command.time);
+	}
+
 	const is_panel = (v: string): v is Panel => ['top', 'blueprint', 'selection', 'time'].includes(v);
 
 	function setup_panels(panel_states: RerunProps['panel_states'] = gradio.props.panel_states) {
@@ -187,6 +208,7 @@
 			console.log('Rerun viewer ready');
 			channel = rr.open_channel('gradio');
 			try_load_value();
+			try_apply_command();
 			setup_panels();
 			// Clear loading status when viewer is ready
 			gradio.dispatch('clear_status', gradio.shared.loading_status);
@@ -195,6 +217,9 @@
 
 		rr._on_raw_event((event: string) => {
 			const { type } = JSON.parse(event);
+			if (type === 'recording_open' || type === 'timeline_change') {
+				try_apply_command();
+			}
 			gradio.dispatch(type, event);
 		});
 
@@ -214,6 +239,14 @@
 	$effect(() => {
 		const value = gradio.props.value;
 		try_load_value(value);
+	});
+
+	$effect(() => {
+		const command = gradio.props.command;
+		if (command != null && command.id !== last_command_id) {
+			pending_command = command;
+			try_apply_command(command);
+		}
 	});
 
 	// Watch for panel_states changes

--- a/frontend/Index.svelte
+++ b/frontend/Index.svelte
@@ -40,7 +40,7 @@
 		height: number | string;
 		streaming: boolean;
 		panel_states: { [K in Panel]: PanelState } | null;
-		command: TimeControlCommand | null | undefined;
+		_command: TimeControlCommand | null | undefined;
 	}
 
 	class RerunGradio extends Gradio<RerunEvents, RerunProps> {}
@@ -52,7 +52,6 @@
 	let channel: LogChannel;
 	let ref = $state<HTMLDivElement>();
 	let dragging = $state(false);
-	let pending_command: TimeControlCommand | null = null;
 	let last_command_id: string | null = null;
 
 	/**
@@ -150,14 +149,12 @@
 		rr.open(value.url);
 	}
 
-	function try_apply_command(
-		command: TimeControlCommand | null | undefined = pending_command ?? gradio.props.command
-	) {
+	function try_apply_command() {
+		const command = gradio.props._command;
 		if (command == null || command.type !== 'time_ctrl' || command.id === last_command_id) {
 			return;
 		}
 
-		pending_command = command;
 		if (rr === undefined || !rr.ready) {
 			return;
 		}
@@ -173,18 +170,11 @@
 		}
 
 		const timeline = rr.get_active_timeline(recording_id);
-		if (timeline === null) {
-			return;
-		}
-		if (command.timeline !== null && timeline !== command.timeline) {
-			return;
-		}
-		if (command.id === last_command_id) {
+		if (timeline === null || (command.timeline !== null && timeline !== command.timeline)) {
 			return;
 		}
 
 		last_command_id = command.id;
-		pending_command = null;
 
 		rr.set_playing(recording_id, command.play);
 		rr.set_current_time(recording_id, timeline, command.time);
@@ -214,12 +204,11 @@
 			gradio.dispatch('clear_status', gradio.shared.loading_status);
 		});
 		rr.on('fullscreen', (on) => rr.toggle_panel_overrides(!on));
+		rr.on('recording_open', () => try_apply_command());
+		rr.on('timeline_change', () => try_apply_command());
 
 		rr._on_raw_event((event: string) => {
 			const { type } = JSON.parse(event);
-			if (type === 'recording_open' || type === 'timeline_change') {
-				try_apply_command();
-			}
 			gradio.dispatch(type, event);
 		});
 
@@ -242,10 +231,9 @@
 	});
 
 	$effect(() => {
-		const command = gradio.props.command;
+		const command = gradio.props._command;
 		if (command != null && command.id !== last_command_id) {
-			pending_command = command;
-			try_apply_command(command);
+			try_apply_command();
 		}
 	});
 

--- a/frontend/Index.svelte
+++ b/frontend/Index.svelte
@@ -18,6 +18,13 @@
 		is_stream: boolean;
 	}
 
+	interface SetTimeCommand {
+		command: 'set_time';
+		timeline: string | null;
+		time: number;
+		play: boolean;
+	}
+
 	interface RerunEvents {
 		change: never;
 		upload: never;
@@ -28,7 +35,7 @@
 	}
 
 	interface RerunProps {
-		value: null | BinaryStream | (FileData | string)[];
+		value: null | BinaryStream | SetTimeCommand | (FileData | string)[];
 		height: number | string;
 		streaming: boolean;
 		panel_states: { [K in Panel]: PanelState } | null;
@@ -99,6 +106,29 @@
 		}
 
 		if (rr == undefined || !rr.ready) {
+			return;
+		}
+
+		if (!Array.isArray(value) && 'command' in value && value.command === 'set_time') {
+			const recording_id = rr.get_active_recording_id();
+			if (recording_id === null) {
+				console.warn('Cannot set Rerun time cursor: no recording is active');
+				return;
+			}
+
+			const active_timeline = rr.get_active_timeline(recording_id);
+			const timeline = value.timeline ?? active_timeline;
+			if (timeline === null) {
+				console.warn('Cannot set Rerun time cursor: no timeline is active');
+				return;
+			}
+
+			if (timeline !== active_timeline) {
+				rr.set_active_timeline(recording_id, timeline);
+			}
+
+			rr.set_playing(recording_id, value.play);
+			rr.set_current_time(recording_id, timeline, value.time);
 			return;
 		}
 

--- a/tests/test_set_time.py
+++ b/tests/test_set_time.py
@@ -6,28 +6,31 @@ import unittest
 from datetime import datetime, timezone
 
 from gradio_rerun import Rerun
-from gradio_rerun.commands import set_time
+from gradio_rerun.commands import SetTimeUpdate, TimeControlCommand, set_time
 
 
 class SetTimeTest(unittest.TestCase):
     """Test command construction and time conversion."""
 
-    def test_sequence_uses_active_timeline_by_default(self) -> None:
-        command = set_time(sequence=42)
+    def command(self, update: SetTimeUpdate) -> TimeControlCommand:
+        command = update["command"]
+        self.assertEqual(update, {"command": command, "__type__": "update"})
+        return command
 
-        self.assertEqual(
-            command,
-            {
-                "command": "set_time",
-                "timeline": None,
-                "time": 42,
-                "play": False,
-            },
-        )
+    def test_sequence_uses_active_timeline_by_default(self) -> None:
+        command = self.command(set_time(sequence=42))
+
+        self.assertEqual(command["type"], "time_ctrl")
+        self.assertEqual(command["timeline"], None)
+        self.assertEqual(command["time"], 42)
+        self.assertEqual(command["play"], False)
+        self.assertIsInstance(command["id"], str)
 
     def test_temporal_values_are_converted_to_nanoseconds(self) -> None:
-        duration = set_time("elapsed", duration=1.5, play=True)
-        timestamp = set_time("capture_time", timestamp=datetime(1970, 1, 1, tzinfo=timezone.utc))
+        duration = self.command(set_time("elapsed", duration=1.5, play=True))
+        timestamp = self.command(
+            set_time("capture_time", timestamp=datetime(1970, 1, 1, tzinfo=timezone.utc)),
+        )
 
         self.assertEqual(duration["time"], 1_500_000_000)
         self.assertTrue(duration["play"])
@@ -35,31 +38,26 @@ class SetTimeTest(unittest.TestCase):
 
     def test_exactly_one_time_value_is_required(self) -> None:
         with self.assertRaisesRegex(ValueError, "exactly one"):
-            set_time()
+            set_time()  # type: ignore[call-overload]
 
         with self.assertRaisesRegex(ValueError, "exactly one"):
             set_time(sequence=1, duration=1.0)  # type: ignore[call-overload]
 
-    def test_component_serializes_command_as_its_value(self) -> None:
+    def test_repeated_commands_have_distinct_ids(self) -> None:
+        first = self.command(set_time(sequence=7))
+        second = self.command(set_time(sequence=7))
+
+        self.assertNotEqual(first["id"], second["id"])
+
+    def test_component_value_remains_recording_data(self) -> None:
         component = Rerun(render=False)
 
-        value = component.postprocess(set_time("frame", sequence=7))
+        value = component.postprocess("https://example.com/recording.rrd")
 
         self.assertEqual(
             value.model_dump(),  # type: ignore[union-attr]
-            {
-                "command": "set_time",
-                "timeline": "frame",
-                "time": 7,
-                "play": False,
-            },
+            ["https://example.com/recording.rrd"],
         )
-
-    def test_component_rejects_unknown_commands(self) -> None:
-        component = Rerun(render=False)
-
-        with self.assertRaisesRegex(ValueError, "Unknown Rerun viewer command"):
-            component.postprocess({"command": "unknown"})
 
 
 if __name__ == "__main__":

--- a/tests/test_set_time.py
+++ b/tests/test_set_time.py
@@ -3,18 +3,21 @@
 from __future__ import annotations
 
 import unittest
+from collections.abc import Mapping
 from datetime import datetime, timezone
+from inspect import signature
 
 from gradio_rerun import Rerun
-from gradio_rerun.commands import SetTimeUpdate, TimeControlCommand, set_time
+from gradio_rerun.commands import set_time
 
 
 class SetTimeTest(unittest.TestCase):
     """Test command construction and time conversion."""
 
-    def command(self, update: SetTimeUpdate) -> TimeControlCommand:
-        command = update["command"]
-        self.assertEqual(update, {"command": command, "__type__": "update"})
+    def command(self, update: Mapping[str, object]) -> Mapping[str, object]:
+        command = update["_command"]
+        self.assertIsInstance(command, Mapping)
+        self.assertEqual(update, {"_command": command, "__type__": "update"})
         return command
 
     def test_sequence_uses_active_timeline_by_default(self) -> None:
@@ -58,6 +61,16 @@ class SetTimeTest(unittest.TestCase):
             value.model_dump(),  # type: ignore[union-attr]
             ["https://example.com/recording.rrd"],
         )
+
+    def test_command_transport_uses_private_parameter(self) -> None:
+        self.assertNotIn("command", signature(Rerun.__init__).parameters)
+        self.assertIn("_command", signature(Rerun.__init__).parameters)
+
+    def test_component_accepts_gradio_command_update(self) -> None:
+        update = set_time(sequence=1)
+        component = Rerun(render=False, _command=update["_command"])
+
+        self.assertEqual(component._command, update["_command"])
 
 
 if __name__ == "__main__":

--- a/tests/test_set_time.py
+++ b/tests/test_set_time.py
@@ -1,0 +1,66 @@
+"""Tests for viewer time cursor commands."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+from gradio_rerun import Rerun
+from gradio_rerun.commands import set_time
+
+
+class SetTimeTest(unittest.TestCase):
+    """Test command construction and time conversion."""
+
+    def test_sequence_uses_active_timeline_by_default(self) -> None:
+        command = set_time(sequence=42)
+
+        self.assertEqual(
+            command,
+            {
+                "command": "set_time",
+                "timeline": None,
+                "time": 42,
+                "play": False,
+            },
+        )
+
+    def test_temporal_values_are_converted_to_nanoseconds(self) -> None:
+        duration = set_time("elapsed", duration=1.5, play=True)
+        timestamp = set_time("capture_time", timestamp=datetime(1970, 1, 1, tzinfo=timezone.utc))
+
+        self.assertEqual(duration["time"], 1_500_000_000)
+        self.assertTrue(duration["play"])
+        self.assertEqual(timestamp["time"], 0)
+
+    def test_exactly_one_time_value_is_required(self) -> None:
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            set_time()
+
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            set_time(sequence=1, duration=1.0)  # type: ignore[call-overload]
+
+    def test_component_serializes_command_as_its_value(self) -> None:
+        component = Rerun(render=False)
+
+        value = component.postprocess(set_time("frame", sequence=7))
+
+        self.assertEqual(
+            value.model_dump(),  # type: ignore[union-attr]
+            {
+                "command": "set_time",
+                "timeline": "frame",
+                "time": 7,
+                "play": False,
+            },
+        )
+
+    def test_component_rejects_unknown_commands(self) -> None:
+        component = Rerun(render=False)
+
+        with self.assertRaisesRegex(ValueError, "Unknown Rerun viewer command"):
+            component.postprocess({"command": "unknown"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Draft status

Blocked on rerun-io/reality#3453 and a WebViewer release that contains `WebViewer.set_time_cursor`.

The final Gradio change has been validated locally against that branch: it replaces the manual recording/timeline/play/time setter sequence with one canonical call and marks the command complete only when that call succeeds.
It is not pushed yet because this repository still depends on `@rerun-io/web-viewer` 0.36.3, which does not expose the method; pushing it now would knowingly break the build.

### Related

* Native Python client integration: rerun-io/reality#3450
* Canonical WebViewer API: rerun-io/reality#3453

### What

Add a small `gradio_rerun.commands.set_time` helper that returns a Gradio property update through a private `_command` prop.

The component's `value` remains recording data, so a cursor command does not replace or pass through RRD postprocessing.
The transport is omitted from the generated public component API and documentation.
Each command has a unique ID, which makes repeated identical seeks observable as new updates.

The frontend treats the durable Gradio prop as the queue until the component and recording are ready.
After the WebViewer dependency is available, it delegates recording/timeline/play/cursor resolution atomically to `WebViewer.set_time_cursor` and retains only Gradio-specific readiness, retry, and deduplication logic.

### Testing

Current pushed branch:

* Python unit tests — 7 passed
* Ruff formatting/lint and mypy — passed
* ESLint and Prettier — passed
* Gradio component CI build — passed

Locally validated canonical WebViewer migration:

* Frontend production bundle — passed
* Browser pixel validation through Gradio 6.20.0 at 1920×1080 with Apple Metal 3 hardware rendering — zero browser console errors
  * Frame 0 rendered red at timeline value `#0`
  * Frame 1 rendered blue at timeline value `#1`
  * Red frame SHA-256: `31a717edab887893d47437550c1e7672096358ed20edd21163d0fe54122c0fa7`
  * Blue frame SHA-256: `8cc922f633d31904bac896f0eb53a28e2d135ab6b060e7350bc804d76bd5474d`

Gradio 6.26.0 still has the pre-existing component-remount failure reproduced with the existing integration, so that remains outside this cursor API migration.

### Compatibility

This is an additive Python API.
Existing RRD URL, file, and streaming values keep their current paths.
The WebViewer dependency will be bumped only after the canonical API is released.

### Agent

🤖 This PR was opened by Codex, a coding agent.
